### PR TITLE
feat(home): add important updates section to home page

### DIFF
--- a/themes/custom-vdm/home/shelves.blade.php
+++ b/themes/custom-vdm/home/shelves.blade.php
@@ -26,6 +26,26 @@
         display: contents; /* Makes the <a> take up the space of its children for clickability */
     }
 </style>
+
+    <div class="card content-wrap">
+        <h2 class="list-heading">Important Updates</h2>
+            <div class="page-content">
+                @php
+                    $importantUpdatesPage = \BookStack\Entities\Models\Page::query()
+                        ->where('slug', 'updates-to-be-shown-at-main-page')
+                        ->whereHas('book', function($query) {
+                            $query->where('slug', 'general-updates');
+                        })
+                        ->first();
+                    if ($importantUpdatesPage) {
+                        echo $importantUpdatesPage->html; 
+                    } else {
+                        echo '<p>Stay tuned for more updates.</p>';
+                    }
+                @endphp
+            </div>
+    </div>
+
     <!-- Search by Category Section -->
     <div class="card content-wrap mb-xl">
         <h2 class="list-heading">Categories</h2><br/>


### PR DESCRIPTION
![Untitled-1](https://github.com/user-attachments/assets/663bc2c9-cd27-4d33-a020-7e9058cad61d)

This commit introduces a new section on the home page to display important updates. The section queries a specific page from the database and renders its content, providing users with timely information. If the page is not found, a placeholder message is displayed to keep users informed.

For edit access to the updates, please refer to the following page to edit the contents inside this section: full url /books/general-updates/page/updates-to-be-shown-at-main-page