### PR TITLE
feat(page): add revision list section with styles and interactions

### DIFF
--- a/themes/custom-vdm/pages/show.blade.php
+++ b/themes/custom-vdm/pages/show.blade.php
@@ -7,6 +7,37 @@
        padding: 4px 8px;    
        border-radius: 20px;
    }
+   
+    /* Revision list styles */
+    .revision-list {
+        max-height: 300px;
+        overflow-y: auto;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        margin-bottom: 1rem;
+    }
+    .revision-list-item {
+        padding: 8px 12px;
+        border-bottom: 1px solid #eee;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+    .revision-list-item > .additional-links {
+        display: none;
+    }
+
+    .revision-list-item:hover {
+        background-color: #f7f7f7;        
+    }
+    .revision-list-item.active {
+        background-color: #e7f3ff;
+    }
+
+    .revision-list-item:hover > .additional-links {
+        display: flex;
+    }
 </style>
 
 @extends('layouts.tri')
@@ -162,6 +193,33 @@
                     <div>{{ trans('entities.pages_is_template') }}</div>
                 </div>
             @endif
+        </div>
+        
+        <br>
+
+        <!-- New Revision List Section -->
+        <div class="revision-section mt-m">
+            <h5>Versions</h5>
+            <div class="revision-list">
+                @foreach($page->revisions()->orderBy('created_at', 'desc')->take(10)->get() as $revision)
+                    <div class="revision-list-item {{ $page->revision_count === $revision->revision_number ? 'active' : '' }}" 
+                         data-revision-id="{{ $revision->id }}" >
+                        <div>
+                            <span class="revision-number">#{{ $revision->revision_number }} - </span>
+                            <span class="revision-name">{{ $revision->summary ? Str::limit($revision->summary, 30) : 'No summary' }}</span>                                            
+                        </div>                        
+                        <div class="revision-date">{{ $revision->created_at->diffForHumans() }}</div>
+                        <div class="additional-links">     
+                            <a href="/books/{{ $page->book->slug }}/page/{{ $page->slug }}/revisions/{{ $revision->id }}" target="_blank"><span class="revision-link">Preview</span></a>
+                            <span class="text-muted opacity-70">&nbsp;|&nbsp;</span>&nbsp;    
+                            <a href="/books/{{ $page->book->slug }}/page/{{ $page->slug }}/revisions/{{ $revision->id }}/changes" target="_blank"><span class="revision-changes">Changes</span></a>
+                        </div>                                           
+                    </div>
+                @endforeach
+            </div>
+            <div class="text-right mt-s">
+                <a href="{{ $page->getUrl('/revisions') }}" class="text-small">{{ trans('common.view_all') }}</a>
+            </div>
         </div>
     </div>
 

--- a/themes/custom-vdm/pages/show.blade.php
+++ b/themes/custom-vdm/pages/show.blade.php
@@ -201,19 +201,19 @@
         <div class="revision-section mt-m">
             <h5>Versions</h5>
             <div class="revision-list">
-                @foreach($page->revisions()->orderBy('created_at', 'desc')->take(10)->get() as $revision)
-                    <div class="revision-list-item {{ $page->revision_count === $revision->revision_number ? 'active' : '' }}" 
+                @foreach($page->revisions()->whereNotNull('summary')->where('summary', '!=', '')->orderBy('created_at', 'desc')->take(10)->get() as $revision)
+                    <div class="revision-list-item {{ $page->revision_count === $revision->revision_number ? 'active' : '' }}"
                          data-revision-id="{{ $revision->id }}" >
                         <div>
                             <span class="revision-number">#{{ $revision->revision_number }} - </span>
-                            <span class="revision-name">{{ $revision->summary ? Str::limit($revision->summary, 30) : 'No summary' }}</span>                                            
+                            <span class="revision-name">{{ Str::limit($revision->summary, 30) }}</span>                                            
                         </div>                        
                         <div class="revision-date">{{ $revision->created_at->diffForHumans() }}</div>
-                        <div class="additional-links">     
+                        <div class="additional-links">    
                             <a href="/books/{{ $page->book->slug }}/page/{{ $page->slug }}/revisions/{{ $revision->id }}" target="_blank"><span class="revision-link">Preview</span></a>
                             <span class="text-muted opacity-70">&nbsp;|&nbsp;</span>&nbsp;    
                             <a href="/books/{{ $page->book->slug }}/page/{{ $page->slug }}/revisions/{{ $revision->id }}/changes" target="_blank"><span class="revision-changes">Changes</span></a>
-                        </div>                                           
+                        </div>                                          
                     </div>
                 @endforeach
             </div>


### PR DESCRIPTION
Add a new section to display page revisions with hover effects and active state styling. The list shows the 10 most recent revisions with summary previews, dates, and links to view changes or preview specific versions. Includes responsive styling and a link to view all revisions.

Update: 
The revisions list was displaying entries with empty or null summaries. Now it only shows revisions that have non-empty summaries, and removes the fallback "No summary" text since it's no longer needed.

![image](https://github.com/user-attachments/assets/7753da72-805f-4932-841d-22618e5aca06)