### PR TITLE
style(views): remove revision number comment and adjust shelf layout

### DIFF
--- a/themes/custom-vdm/pages/show.blade.php
+++ b/themes/custom-vdm/pages/show.blade.php
@@ -205,7 +205,7 @@
                     <div class="revision-list-item {{ $page->revision_count === $revision->revision_number ? 'active' : '' }}"
                          data-revision-id="{{ $revision->id }}" >
                         <div>
-                            <span class="revision-number">#{{ $revision->revision_number }} - </span>
+                            {{-- <span class="revision-number">#{{ $revision->revision_number }} - </span> --}}
                             <span class="revision-name">{{ Str::limit($revision->summary, 30) }}</span>                                            
                         </div>                        
                         <div class="revision-date">{{ $revision->created_at->diffForHumans() }}</div>

--- a/themes/custom-vdm/shelves/show.blade.php
+++ b/themes/custom-vdm/shelves/show.blade.php
@@ -88,13 +88,12 @@
 
         <div class="flex-container-row wrap v-center">
             <h1 class="flex fit-content break-text">{{ $shelf->name }}</h1>
-            <div class="flex"></div>
             <div class="flex fit-content text-m-right my-m ml-m">
                 @include('common.sort', $listOptions->getSortControlData())
             </div>
         </div>
 
-        <div class="flex-container-row wrap v-center">
+        <div class="flex-container-column wrap v-center">
             <h2 class="list-heading mb-s">Important Updates</h2>
         
             @php
@@ -111,8 +110,7 @@
             @if ($updatePages->isNotEmpty())
                 <div class="page-list">
                     @foreach ($updatePages as $page)
-                        <div class="page-item"> 
-        
+                        <div class="page-item">         
                             <input  type="checkbox"
                                     id="page-toggle-{{ $page->id }}"
                                     class="page-toggle-input">


### PR DESCRIPTION
- Comment out revision number display in page view as it's no longer needed
- Simplify shelf view layout by removing empty flex div and changing container direction
- Clean up page item markup by removing extra whitespace